### PR TITLE
fix #180: Update app panel login message

### DIFF
--- a/backend/src/zelthy/apps/shared/platformauth/templates/app_panel/app_panel_login.html
+++ b/backend/src/zelthy/apps/shared/platformauth/templates/app_panel/app_panel_login.html
@@ -55,7 +55,7 @@
             <img id="ipad-logo" src="{% static 'app_panel/images/zelthyLogoIpad.svg' %}" alt="#">
             <img id="iphone-logo" src="{% static 'app_panel/images/zelthyLogoIphone.svg' %}" alt="#">
           </div>
-          <p class="content-heading">build complex healthcare applications effortlessly</p>
+          <p class="content-heading">the framework for building business apps</p>
         </div>
       </div>
 


### PR DESCRIPTION
Closes Healthlane-Technologies/zelthy3#180

- Change the app_panel_login message to `the framework for building business apps`

I wasn't able to get the app running due to errors when running `python manage.py ws_makemigration <project_name>` in the associated docker container, so unfortunately I can't provide a screenshot.

